### PR TITLE
Return error when loading nonexistent module

### DIFF
--- a/key.go
+++ b/key.go
@@ -131,8 +131,7 @@ func initialize(modulePath string) (ctx, error) {
 		return module, nil
 	}
 
-	newModule := ctx(pkcs11.New(modulePath))
-
+	newModule := pkcs11.New(modulePath)
 	if newModule == nil {
 		return nil, fmt.Errorf("unable to load PKCS#11 module")
 	}
@@ -142,9 +141,9 @@ func initialize(modulePath string) (ctx, error) {
 		return nil, err
 	}
 
-	modules[modulePath] = newModule
+	modules[modulePath] = ctx(newModule)
 
-	return newModule, nil
+	return ctx(newModule), nil
 }
 
 // New instantiates a new handle to a PKCS #11-backed key.

--- a/key_test.go
+++ b/key_test.go
@@ -254,6 +254,16 @@ func sign(t *testing.T, ps *Key) []byte {
 	return output
 }
 
+func TestInitializeBadModule(t *testing.T) {
+	ctx, err := initialize("/dev/null")
+	if err == nil {
+		t.Errorf("Expected failure when initializing modulePath /dev/null, got none")
+	}
+	if ctx != nil {
+		t.Errorf("Expected nil ctx when initializing modulePath /dev/null")
+	}
+}
+
 func TestSign(t *testing.T) {
 	ps := setup(t, "rsa")
 	sig := sign(t, ps)


### PR DESCRIPTION
Without this, providing a nonexistent module will produce a panic.