### PR TITLE
Improve error messages

### DIFF
--- a/key_test.go
+++ b/key_test.go
@@ -342,7 +342,7 @@ func TestEcKeyErrors(t *testing.T) {
 	if err == nil {
 		t.Errorf("Unexpected success")
 	}
-	if !strings.EqualFold(err.Error(), "public key not found") {
+	if !strings.EqualFold(err.Error(), "getting public key: not found") {
 		t.Errorf("Unexpected error value: %v", err)
 	}
 
@@ -351,7 +351,7 @@ func TestEcKeyErrors(t *testing.T) {
 	if err == nil {
 		t.Errorf("Unexpected success")
 	}
-	if !strings.EqualFold(err.Error(), "invalid EC Point") {
+	if !strings.EqualFold(err.Error(), "getting public key: invalid EC Point") {
 		t.Errorf("Unexpected error value: %v", err)
 	}
 }

--- a/pool.go
+++ b/pool.go
@@ -93,7 +93,7 @@ func (p *Pool) Destroy() error {
 	for i := 0; i < p.totalCount; i++ {
 		err := p.get().Destroy()
 		if err != nil {
-			return fmt.Errorf("destroy error: %s", err)
+			return fmt.Errorf("pkcs11key: destroy: %s", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Public methods all prefix "pkcs11key:", private methods never do.
Fix capitalization to match Go style (never).
Fix some methods to not use named returns.