### PR TITLE
Decryption Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 PKCS11Key
 ========
 
-The pkcs11key package implements a crypto.Signer interface for a PKCS#11 private key.
-
-[![Build Status](https://travis-ci.org/letsencrypt/pkcs11key.svg)](https://travis-ci.org/letsencrypt/pkcs11key)
+The pkcs11key package implements the crypto.Signer & crypto.Decrypter interfaces for a PKCS#11 private key.
 
 ## License summary
 Some of this code is Copyright (c) 2014 CloudFlare Inc., some is Copyright (c)
-2015 Internet Security Research Group.
+2015 Internet Security Research Group., some is Copyright (c) Campbell Software Solutions Ltd 2016.
 
 The code is licensed under the BSD 2-clause license. See the LICENSE file for more details.

--- a/key.go
+++ b/key.go
@@ -92,24 +92,24 @@ type ctx interface {
 // to login repeatedly with an incorrect PIN, locking the PKCS#11 token.
 type Key struct {
 	// The PKCS#11 library to use
-	module             ctx
+	module ctx
 
 	// The label of the token to be used (mandatory).
 	// We will automatically search for this in the slot list.
-	tokenLabel         string
+	tokenLabel string
 
 	// The PIN to be used to log in to the device
-	pin                string
+	pin string
 
 	// The public key corresponding to the private key.
-	publicKey          crypto.PublicKey
+	publicKey crypto.PublicKey
 
 	// The an ObjectHandle pointing to the private key on the HSM.
-	privateKeyHandle   pkcs11.ObjectHandle
+	privateKeyHandle pkcs11.ObjectHandle
 
 	// A handle to the session used by this Key.
-	session            *pkcs11.SessionHandle
-	sessionMu          sync.Mutex
+	session   *pkcs11.SessionHandle
+	sessionMu sync.Mutex
 
 	// True if the private key has the CKA_ALWAYS_AUTHENTICATE attribute set.
 	alwaysAuthenticate bool

--- a/key.go
+++ b/key.go
@@ -590,7 +590,7 @@ func (ps *Key) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) ([
 
 	//Decrypt
 	if err := ps.module.DecryptInit(*ps.session, mechanism, ps.privateKeyHandle); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("pkcs11key: decrypt: %s", err)
 	}
 	return ps.module.Decrypt(*ps.session, msg)
 }

--- a/key_test.go
+++ b/key_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/miekg/pkcs11"
 	"errors"
+	"github.com/miekg/pkcs11"
 )
 
 type mockCtx struct {


### PR DESCRIPTION
We recently needed the ability to perform decryption of data using a private key held in a PKCS11 token.

The `pkcs11key` package has been extended to implement the `crypto.Decrypter` interface with appropriate unit tests added.

The functionality has been tested in _real life_ with RSA keys. This is currently used in some of our internal software and will decrypt data encrypted using `rsa.EncryptPKCS1v15`. I've added code for ECDSA keys but I don't have any tokens that support this so it is untested and may not work.

I've put this online as I thought others may find the decryption functionality useful. I understand you may not want to accept this request as decryption is a separate concern from digital signatures. If not, I am happy to keep our repository online. However, it made sense to me to extend this library as a lot of the work involved in initialising a token, finding the key, extracting the public key etc is exactly the same.
