### PR TITLE
Set GOMAXPROCS to at least number of keys in pool.

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -70,7 +70,7 @@ func NewPool(n int, modulePath, tokenLabel, pin, privateKeyLabel string) (*Pool,
 	// have at least as many threads as sessions in the pool to achieve full
 	// throughput.
 	if runtime.GOMAXPROCS(0) < n {
-		return fmt.Errorf("pkcs11key.NewPool: GOMAXPROCS (%d) is lower than number of "+
+		return nil, fmt.Errorf("pkcs11key.NewPool: GOMAXPROCS (%d) is lower than number of "+
 			"requested sessions (%d). Increase GOMAXPROCS or decrease the number "+
 			"of sessions.", runtime.GOMAXPROCS(0), n)
 	}

--- a/pool.go
+++ b/pool.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"fmt"
 	"io"
+	"runtime"
 	"sync"
 )
 

--- a/pool.go
+++ b/pool.go
@@ -65,6 +65,12 @@ func (p *Pool) Public() crypto.PublicKey {
 
 // NewPool creates a pool of Keys of size n.
 func NewPool(n int, modulePath, tokenLabel, pin, privateKeyLabel string) (*Pool, error) {
+	// Some modules may block their thread during operations, so it's important to
+	// have at least as many threads as sessions in the pool to achieve full
+	// throughput.
+	if runtime.GOMAXPROCS(0) < n {
+		runtime.GOMAXPROCS(n)
+	}
 	var err error
 	signers := make([]*Key, n)
 	for i := 0; i < n; i++ {

--- a/pool.go
+++ b/pool.go
@@ -70,7 +70,9 @@ func NewPool(n int, modulePath, tokenLabel, pin, privateKeyLabel string) (*Pool,
 	// have at least as many threads as sessions in the pool to achieve full
 	// throughput.
 	if runtime.GOMAXPROCS(0) < n {
-		runtime.GOMAXPROCS(n)
+		return fmt.Errorf("pkcs11key.NewPool: GOMAXPROCS (%d) is lower than number of "+
+			"requested sessions (%d). Increase GOMAXPROCS or decrease the number "+
+			"of sessions.", runtime.GOMAXPROCS(0), n)
 	}
 	var err error
 	signers := make([]*Key, n)
@@ -100,7 +102,7 @@ func (p *Pool) Destroy() error {
 	for i := 0; i < p.totalCount; i++ {
 		err := p.get().Destroy()
 		if err != nil {
-			return fmt.Errorf("destroy error: %s", err)
+			return fmt.Errorf("pkcs11key: destroy error: %s", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Some (most?) PKCS#11 modules will block the thread they are on during
operations. This means that if you're running pkcs11key on a machine that has
fewer CPUs (and thus a smaller GOMAXPROCS) than your HSM, you will not be able
to utilize the full performance of your HSM, unless you increase GOMAXPROCS.
This change produces an error to warn you about that.