### PR TITLE
Remove check for GOMAXPROCS >= sessionCount.

### DIFF
--- a/pkcs11key_bench_test.go
+++ b/pkcs11key_bench_test.go
@@ -92,6 +92,26 @@ func BenchmarkPKCS11(b *testing.B) {
 	// nanoseconds per op, but we're also interested in the total throughput.
 	start := time.Now()
 
+	// Note: In high-performance HSMs, we expect there to be multiple cores,
+	// allowing multiple signing operations to be inflight at once - that's what
+	// the sessionCount parameter is for. However, each individual call to
+	// CreateCertificate (which in turn calls pool.Sign) will block until it is
+	// done. For instance, consider an HSM with 32 cores. If the benchmark-running
+	// machine has 4 CPUs and thus GOMAXPROCS=4, b.RunParallel will run 4
+	// goroutines requesting signing, and the benchmark will not reach peak
+	// performance.
+	//
+	// Note that this does not have to do with CGO and the Go scheduler at all. If
+	// a C function blocks for more than 20us (signatures take roughly 10ms), the Go
+	// scheduler will spawn an extra thread so other goroutines can keep running.
+	// http://stackoverflow.com/a/28356944/363869
+	//
+	// In practice, this means that code using a Pool should be calling it from at
+	// least as many goroutines as there are entries in the pool. In a typical
+	// HTTP or RPC setting, where each request is handled in its own goroutine,
+	// this will not be a problem.
+	b.SetParallelism(*sessionCount)
+
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			_, err = x509.CreateCertificate(rand.Reader, &template, &template, template.PublicKey, pool)

--- a/pool.go
+++ b/pool.go
@@ -4,7 +4,6 @@ import (
 	"crypto"
 	"fmt"
 	"io"
-	"runtime"
 	"sync"
 )
 
@@ -66,14 +65,6 @@ func (p *Pool) Public() crypto.PublicKey {
 
 // NewPool creates a pool of Keys of size n.
 func NewPool(n int, modulePath, tokenLabel, pin string, publicKey crypto.PublicKey) (*Pool, error) {
-	// Some modules may block their thread during operations, so it's important to
-	// have at least as many threads as sessions in the pool to achieve full
-	// throughput.
-	if runtime.GOMAXPROCS(0) < n {
-		return nil, fmt.Errorf("pkcs11key.NewPool: GOMAXPROCS (%d) is lower than number of "+
-			"requested sessions (%d). Increase GOMAXPROCS or decrease the number "+
-			"of sessions.", runtime.GOMAXPROCS(0), n)
-	}
 	var err error
 	signers := make([]*Key, n)
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
It turns out the GOMAXPROCS setting was a red herring: It only affected the
benchmark, because benchmarks default to running N parallel loops, where
N==GOMAXPROCS.