### PR TITLE
Remove pkcs11key_stub.

### DIFF
--- a/pkcs11key_stub.go
+++ b/pkcs11key_stub.go
@@ -1,6 +1,0 @@
-// Package pkcs11key exists to satisfy Go build tools.
-// Some Go tools will complain "no buildable Go source files in ..." because
-// pkcs11key.go only builds when the pkcs11 tag is supplied. This empty file
-// exists only to suppress that error, which blocks completion in some tools
-// (specifically godep).
-package pkcs11key

--- a/v4/pkcs11key_stub.go
+++ b/v4/pkcs11key_stub.go
@@ -1,6 +1,0 @@
-// Package pkcs11key exists to satisfy Go build tools.
-// Some Go tools will complain "no buildable Go source files in ..." because
-// pkcs11key.go only builds when the pkcs11 tag is supplied. This empty file
-// exists only to suppress that error, which blocks completion in some tools
-// (specifically godep).
-package pkcs11key


### PR DESCRIPTION
These are a holdover when the pkcs11key package used to be gated on a
build tag. That's no longer the case, so remove them.