### PR TITLE
Improve documentation.

### DIFF
--- a/key.go
+++ b/key.go
@@ -1,6 +1,9 @@
 // Package pkcs11key implements crypto.Signer for PKCS #11 private keys.
-// See ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-11/v2-30/pkcs-11v2-30b-d6.pdf for
-// details of the Cryptoki PKCS#11 API.
+// See https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.pdf
+// for details of the Cryptoki PKCS#11 API.
+// See https://github.com/letsencrypt/pkcs11key/blob/master/test.sh for examples
+// of how to test and/or benchmark.
+// Latest version of this package is v4: import "github.com/letsencrypt/pkcs11key/v4"
 package pkcs11key
 
 import (

--- a/test.sh
+++ b/test.sh
@@ -10,6 +10,14 @@
 # export MODULE=/usr/local/lib/libpkcs11-proxy.so PKCS11_PROXY_SOCKET=tcp://hsm.example.com:5657
 # bash test.sh
 #
+# To test with a YubiKey 4:
+#
+# ykman piv generate-key --algorithm ECCP256 9a pubkey.pem
+# ykman piv generate-certificate --pin 123456 --subject "yubico" 9a pubkey.pem
+# ykman piv export-certificate 9a cert.pem
+# go test -bench=. -module /usr/lib/x86_64-linux-gnu/opensc-pkcs11.so \
+#   -pin 123456 -cert cert.pem -tokenLabel yubico
+#
 # You can also override the number of sessions by setting the SESSIONS variable.
 
 if [ -r /proc/brcm_monitor0 ]; then
@@ -48,9 +56,11 @@ go test github.com/letsencrypt/pkcs11key/v4
 
 # Run the benchmark. Arguments: $1: token label, $2: certificate filename
 function bench {
-  go test github.com/letsencrypt/pkcs11key/v4 -module ${MODULE} \
+  go test github.com/letsencrypt/pkcs11key/v4
+    -module ${MODULE} \
     -test.run xxxNONExxx \
-    -pin 1234 -tokenLabel ${1} \
+    -pin 1234 \
+    -tokenLabel ${1} \
     -cert ${2} \
     -test.bench Bench \
     -benchtime 10s \

--- a/test.sh
+++ b/test.sh
@@ -56,7 +56,7 @@ go test github.com/letsencrypt/pkcs11key/v4
 
 # Run the benchmark. Arguments: $1: token label, $2: certificate filename
 function bench {
-  go test github.com/letsencrypt/pkcs11key/v4
+  go test github.com/letsencrypt/pkcs11key/v4 \
     -module ${MODULE} \
     -test.run xxxNONExxx \
     -pin 1234 \

--- a/v4/key.go
+++ b/v4/key.go
@@ -398,9 +398,9 @@ func (ps *Key) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) (signatu
 		return nil, errors.New("pkcs11key: session was nil")
 	}
 
-	// When the alwaysAuthenticate bit is true (e.g. on a Yubikey NEO in PIV mode),
+	// When the alwaysAuthenticate bit is true (e.g. on a YubiKey in PIV mode),
 	// each Sign has to include a Logout/Login, or the next Sign request will get
-	// CKR_USER_NOT_LOGGED_IN. This is very slow, but on the NEO it's not possible
+	// CKR_USER_NOT_LOGGED_IN. This is very slow, but on the YubiKey it's not possible
 	// to clear the CKA_ALWAYS_AUTHENTICATE bit, so this is the only available
 	// workaround.
 	// Also, since logged in / logged out is application state rather than session

--- a/v4/key.go
+++ b/v4/key.go
@@ -1,6 +1,8 @@
 // Package pkcs11key implements crypto.Signer for PKCS #11 private keys.
-// See ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-11/v2-30/pkcs-11v2-30b-d6.pdf for
-// details of the Cryptoki PKCS#11 API.
+// See https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.pdf
+// for details of the Cryptoki PKCS#11 API.
+// See https://github.com/letsencrypt/pkcs11key/blob/master/test.sh for examples
+// of how to test and/or benchmark.
 package pkcs11key
 
 import (

--- a/v4/pkcs11key_bench_test.go
+++ b/v4/pkcs11key_bench_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 var module = flag.String("module", "", "Path to PKCS11 module")
-var tokenLabel = flag.String("tokenLabel", "", "Token label")
+var tokenLabel = flag.String("tokenLabel", "", "Token label (e.g. from `pkcs11-tool -L`)")
 var pin = flag.String("pin", "", "PIN")
 var certFile = flag.String("cert", "", "Certificate to sign with (PEM)")
 var sessionCount = flag.Int("sessions", runtime.GOMAXPROCS(-1), `Number of PKCS#11 sessions to use.
@@ -34,8 +34,8 @@ func readCert(certContents []byte) (*x509.Certificate, error) {
 // BenchmarkPKCS11 signs a certificate repeatedly using a PKCS11 token and
 // measures speed. To run (with SoftHSM):
 // go test -bench=. -benchtime 5s ./crypto/pkcs11key/ \
-//   -module /usr/lib/softhsm/libsofthsm.so -token-label "softhsm token" \
-//   -pin 1234 -private-key-label "my key" -cpu 4
+//   -module /usr/lib/softhsm/libsofthsm.so -tokenLabel "softhsm token" \
+//   -pin 1234 -sessions 4
 // You can adjust benchtime if you want to run for longer or shorter, and change
 // the number of CPUs to select the parallelism you want.
 func BenchmarkPKCS11(b *testing.B) {


### PR DESCRIPTION
Link to the latest version of the PKCS#11 standard, now managed by OASIS
(and on HTTPS instead of FTP).

Reference the module path with major version from the old-style path
documentation.

Give an example of how to benchmark with a Yubikey.

Fix command line flags in comment in pkcs11key_bench_test.go.