### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,15 @@ jobs:
           - "stable"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install SoftHSM
       run: sudo apt-get install -y softhsm2
 
     - name: Set up Go ${{ matrix.GO_VERSION }}
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.GO_VERSION }}
         cache: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on: [push, pull_request]
 
 env:
-    GODEBUG: cgocheck=2
+    GOEXPERIMENT: cgocheck2
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.24.x"
-          - "1.25.x"
+          - "oldstable"
+          - "stable"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         GO_VERSION:
-          - "1.17.8"
-          - "1.20.4"
-          - "1.20.5"
+          - "1.24.x"
+          - "1.25.x"
 
     steps:
     - uses: actions/checkout@v3
 
     - name: Install SoftHSM
-      run: sudo apt-get install -y softhsm
+      run: sudo apt-get install -y softhsm2
 
     - name: Set up Go ${{ matrix.GO_VERSION }}
       uses: actions/setup-go@v4


### PR DESCRIPTION
- Use modern Go versions.
- Use the current name of the softhsm package in ubuntu (softhsm2)
- Switch from GODEBUG=cgocheck=2 (unsupported, errors out) to the newer GOEXPERIMENT=cgocheck2

Fixes #40.